### PR TITLE
changes to logic

### DIFF
--- a/cipher_Ca
+++ b/cipher_Ca
@@ -51,17 +51,22 @@ int cypher(char myChar, int keyUsed){
 
     if(isupper(myChar)){
         
-        int shiftLetter = shiftMod + SHIFTVALUP;
-        return shiftLetter; 
+        if (shiftMod <18){
+            int shiftLetter = shiftMod + SHIFTVALLOW;
+            return shiftLetter; 
+        }
+        else {
+            int shiftLetter = shiftMod + SHIFTVALUP;
+            return shiftLetter;
+        }
         
     }
     else
     {
-        if (sumKey >= 104 ){
+        if (shiftMod <18){
             
             int shiftLetter = shiftMod + SHIFTVALLOW2; 
             return shiftLetter; 
-            
         }
         else
         {


### PR DESCRIPTION
Basing the transition on ASCII value resulted in incorrect results. Basing the transition on the size of the returned modulo value works correctly. This was not changed in the previous version. It still based the assigning of the new value on ASCII value 